### PR TITLE
Take ErlyDTL from the official (maintained) repo.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-       {erlydtl, ".*", {git, "git://github.com/russelldb/erlydtl.git", "master"}}
+       {erlydtl, ".*", {git, "git://github.com/evanmiller/erlydtl.git", "master"}}
 ]}.
 
 {escript_incl_apps, [erlydtl]}.


### PR DESCRIPTION
Hi,

I know it's been a long time since you touched this project, but erldocs.com is a very handy piece of work and I would like to later push my compiled docs of the latest Erlang/OTP builds.

So this PR fixes ErlyDTL's compile error on Erlang ≥R13B04. Now erldocs builds without issues.

I am compiling the docs and will send you something via GitHub or Twitter.
Thanks for your good work.
